### PR TITLE
修改编辑页面布局

### DIFF
--- a/fame-admin/src/components/page/Article.vue
+++ b/fame-admin/src/components/page/Article.vue
@@ -7,7 +7,7 @@
       :model="article"
     >
       <el-row :gutter="30">
-        <el-col :xs="24" :sm="16" :md="16" :lg="16">
+        <el-col :xs="24" :sm="16" :md="19" :lg="19">
           <el-form-item prop="title">
             <el-input
               v-model="article.title"
@@ -19,7 +19,7 @@
             <!-- 键修饰符，键别名 -->
           </el-form-item>
         </el-col>
-        <el-col :xs="24" :sm="8" :md="8" :lg="8">
+        <el-col :xs="24" :sm="8" :md="5" :lg="5">
           <div class="panel">
             <div class="panel-content">
               <el-form-item label="标签">


### PR DESCRIPTION
markdown 变大，右边类型和标签变小。 效果如下：分别为15寸 MacBook Pro 屏和23.8寸4K 屏
<img width="1920" alt="Screen Shot 2019-05-19 at 02 10 25" src="https://user-images.githubusercontent.com/19926035/57973435-71780300-79db-11e9-9ed3-3720c6fd72ad.png">
<img width="1680" alt="Screen Shot 2019-05-19 at 02 10 13" src="https://user-images.githubusercontent.com/19926035/57973436-71780300-79db-11e9-84d8-38de567a9e18.png">
